### PR TITLE
Set new testfile directory structure

### DIFF
--- a/tests/GeneratorConfig.json
+++ b/tests/GeneratorConfig.json
@@ -1,6 +1,5 @@
 {
-  "inDir": "<inDir>",
-  "outDir": "<inDir>",
+  "testDir": "<path_to_test_dir>",
   "testedExecutablePaths": {
     "<ccid>": "<path_to_generator_exe>"
   },

--- a/tests/input/.gitkeep
+++ b/tests/input/.gitkeep
@@ -1,2 +1,0 @@
-This file is useless. Just meant to keep the directory around. Delete it if
-you want, but it won't affect your tests.

--- a/tests/output/.gitkeep
+++ b/tests/output/.gitkeep
@@ -1,2 +1,0 @@
-This file is useless. Just meant to keep the directory around. Delete it if
-you want, but it won't affect your tests.


### PR DESCRIPTION
* Config file now points to a `testDir` instead of both an `inputDir` and `outputDir`.