### PR TITLE
Add a pre-commit script that students can use to verify their test st…

### DIFF
--- a/tests/GeneratorConfig.json
+++ b/tests/GeneratorConfig.json
@@ -1,5 +1,5 @@
 {
-  "testDir": "<path_to_test_dir>",
+  "testDir": "<path_to_testfiles>",
   "testedExecutablePaths": {
     "<ccid>": "<path_to_generator_exe>"
   },

--- a/tests/pre-commit
+++ b/tests/pre-commit
@@ -3,28 +3,6 @@
 # Place this script in .git/hooks/ to ensure that your test structure
 # is correct on every commit. You can also run it ad hoc.
 
-print_tree() {
-    local dir=$1
-    local prefix=$2
-
-    local files=("$dir"/*)
-    local last=${files[-1]}
-
-    for file in "${files[@]}"; do
-        local base="$(basename "$file")"
-        if [[ "$file" == "$last" ]]; then
-            echo "${prefix}└── $base"
-            new_prefix="${prefix}    "
-        else
-            echo "${prefix}├── $base"
-            new_prefix="${prefix}│   "
-        fi
-        if [ -d "$file" ]; then
-            print_tree "$file" "$new_prefix"
-        fi
-    done
-}
-
 # Color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -59,7 +37,6 @@ fi
 # Assert that the expected first package is present.
 if [ ! -d $EXPECTED_PACKAGE ]; then
     echo -e "--- ${RED}ERROR:${NC} Missing a self-named package in testfiles!"
-    print_tree $REPO_ROOT ""
     echo -e "--- Expected a package named ${YELLOW}~/tests/testfiles/${PROJECT_DIR_NAME}${NC}" 
     exit 1
 fi

--- a/tests/pre-commit
+++ b/tests/pre-commit
@@ -37,9 +37,12 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # Extract the name of the project directory from the repository root path
 PROJECT_DIR_NAME=$(basename "$REPO_ROOT")
 
+# The team name is the substring of the project directory from the right of the
+# first '-'. For example vcalc-unicorn -> unicorn
+TEAM_NAME=${PROJECT_DIR_NAME#*-}
 TEST_DIR="${REPO_ROOT}/tests"
 TESTFILES_DIR="${TEST_DIR}/testfiles"
-EXPECTED_PACKAGE="${TESTFILES_DIR}/${PROJECT_DIR_NAME}"
+EXPECTED_PACKAGE="${TESTFILES_DIR}/${TEAM_NAME}"
 
 # Assert that the test directory is present.
 if [ ! -d $TEST_DIR ]; then

--- a/tests/pre-commit
+++ b/tests/pre-commit
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Place this script in .git/hooks/ to ensure that your test structure
+# is correct on every commit. You can also run it ad hoc.
+
+print_tree() {
+    local dir=$1
+    local prefix=$2
+
+    local files=("$dir"/*)
+    local last=${files[-1]}
+
+    for file in "${files[@]}"; do
+        local base="$(basename "$file")"
+        if [[ "$file" == "$last" ]]; then
+            echo "${prefix}└── $base"
+            new_prefix="${prefix}    "
+        else
+            echo "${prefix}├── $base"
+            new_prefix="${prefix}│   "
+        fi
+        if [ -d "$file" ]; then
+            print_tree "$file" "$new_prefix"
+        fi
+    done
+}
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Get the full path to the git repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Extract the name of the project directory from the repository root path
+PROJECT_DIR_NAME=$(basename "$REPO_ROOT")
+
+TEST_DIR="${REPO_ROOT}/tests"
+TESTFILES_DIR="${TEST_DIR}/testfiles"
+EXPECTED_PACKAGE="${TESTFILES_DIR}/${PROJECT_DIR_NAME}"
+
+# Assert that the test directory is present.
+if [ ! -d $TEST_DIR ]; then
+    echo -e "${RED} Could not find expected directory: ${TEST_DIR} ${NC}"
+    exit 1
+fi
+
+# Assert that a testfiles directory is present.
+if [ ! -d $TESTFILES_DIR ]; then
+    echo -e "${RED}Could not find expected directory: ${TESTFILES_DIR}${NC}"
+    exit 1
+fi
+
+# Assert that the expected first package is present.
+if [ ! -d $EXPECTED_PACKAGE ]; then
+    echo -e "--- ${RED}ERROR:${NC} Missing a self-named package in testfiles!"
+    print_tree $REPO_ROOT ""
+    echo -e "--- Expected a package named ${YELLOW}~/tests/testfiles/${PROJECT_DIR_NAME}${NC}" 
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
I have been doing a mock marking of the F23 VCalc projects this week. I found that submissions with minor deviations from the naming spec for test cases could be annoying. For example a project with name `vcalc-team-unicorn` with a test package named `vcalc-team-unicorn` instead of `team-unicorn` (this messes up the grader because it expects parity between the package names and project names.) Also common was switching the case such as `teamUnicorn`. And of course several which did not nest their tests in a self-named package at all.

My hope is that this PR will help mitigate that. We place a script in the `tests` directory of the project that will check if there exists a self named package in `testfiles`. The script can be moved into `.git/hooks` to run on every commit, but also works in place.

If it looks good then I can also put the script on the other base repos.